### PR TITLE
Version updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.15 AS TERRAFORM
 
 RUN apk --no-cache add gpgme
 
-ENV TERRAFORM_VERSION 1.2.5
+ENV TERRAFORM_VERSION 1.2.9
 COPY sig/hashicorp.asc .
 ADD https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip .
 ADD https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS .
@@ -29,7 +29,7 @@ RUN openssl sha1 -sha256 /aws-iam-authenticator
 RUN chmod +x /aws-iam-authenticator
 
 # Main image includes golang, terraform, kubectl, Keycloak
-FROM alpine:3.11
+FROM alpine:3.15
 
 RUN apk add --no-cache \
     curl \
@@ -47,7 +47,7 @@ RUN mkdir -m 0777 ${GOPATH} ${GOPATH}/src ${GOPATH}/bin
 COPY --from=TERRAFORM terraform /usr/bin
 
 ## Install Kubectl
-ENV KUBECTL_VERSION v1.24.0
+ENV KUBECTL_VERSION v1.25.0
 ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/bin
 RUN chmod a+x /usr/bin/kubectl
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ stage('Build') {
 ```
 
 ## What is installed on this image?
-- Version [1.2.X](https://releases.hashicorp.com/terraform/1.2.5/) of infrastructure as code tool Terraform
+- Version [1.2.X](https://releases.hashicorp.com/terraform/1.2.9/) of infrastructure as code tool Terraform
 - Version [1.21.X](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html) of command-line tool aws-iam-authenticator
-- Version [1.24.X](https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubectl) of kubectl, a command-line tool that allows you to run commands against Kubernetes clusters
-- Packages included in [Alpine 3.11](https://alpinelinux.org/posts/Alpine-3.11.0-released.html)
+- Version [1.25.X](https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl) of kubectl, a command-line tool that allows you to run commands against Kubernetes clusters
+- Packages included in [Alpine 3.15](https://alpinelinux.org/posts/Alpine-3.15.0-released.html)


### PR DESCRIPTION
Resolved [CVE-2022-37434](https://avd.aquasec.com/nvd/cve-2022-37434) with alpine main image version bump.